### PR TITLE
feat: add funcs in simple attribute

### DIFF
--- a/.changelog/26.txt
+++ b/.changelog/26.txt
@@ -1,0 +1,18 @@
+```release-note:feature
+`attribute/int64` - Add funcs `SetPtr`, `SetInt`, `SetInt8`, `SetInt16`, `SetInt32`, `SetInt64`, `SetIntPtr`, `SetInt8Ptr`, `SetInt16Ptr`, `SetInt32Ptr`, `SetInt64Ptr`, `GetInt`, `GetInt8`, `GetInt16`, `GetInt32`, `GetInt64`, `GetIntPtr`, `GetInt8Ptr`, `GetInt16Ptr`, `GetInt32Ptr`, `GetInt64Ptr`
+```
+
+```release-note:feature
+`attribute/float64` - Add func `SetFloat32`, `SetFloat64`, `SetFloat32Ptr`, `SetFloat64Ptr`, `GetFloat32`, `GetFloat64`, `GetFloat32Ptr`, `GetFloat64Ptr`
+```
+
+```release-note:feature
+`attribute/string` - Add func `SetPtr`
+```
+```release-note:breaking-change
+`attribute/string` - Now `Set` func set attribute to null if value is empty string
+```
+
+```release-note:feature
+`attribute/bool` - Add func `SetPtr`
+```

--- a/.github/workflows/go-generate.yml
+++ b/.github/workflows/go-generate.yml
@@ -17,7 +17,12 @@ jobs:
       - uses: actions/setup-go@v4
       - run: go generate ./...
       - run: git status --ignored
+      - name: git diff
+        continue-on-error: true
+        run: |
+          git diff --compact-summary --exit-code
       - uses: stefanzweifel/git-auto-commit-action@v4
+        if: failure() # Run only if previous step have diff 
         with:
           add_options: '--force'
           commit_message: 'ci(generate): changes by go generate'

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Generate",
+            "type": "shell",
+            "command": "make -j 6 generate"
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,6 @@ submodules:
 	@git submodule update --init --recursive
 	@git config core.hooksPath githooks
 	@git config submodule.recurse true
+
+generate:
+	go generate ./...

--- a/bool_value.go
+++ b/bool_value.go
@@ -67,7 +67,17 @@ func (v *BoolValue) GetPtr() *bool {
 }
 
 func (v *BoolValue) Set(s bool) {
+
 	v.BoolValue = basetypes.NewBoolValue(s)
+}
+
+func (v *BoolValue) SetPtr(s *bool) {
+	if s == nil {
+		v.BoolValue = basetypes.NewBoolNull()
+		return
+	}
+
+	v.BoolValue = basetypes.NewBoolPointerValue(s)
 }
 
 func (v *BoolValue) SetNull() {

--- a/bool_value.go
+++ b/bool_value.go
@@ -58,19 +58,24 @@ func NewBoolPointerValue(s *bool) BoolValue {
 
 // * CustomFunc
 
+// Get returns the known Bool value. If Bool is null or unknown, returns false.
 func (v *BoolValue) Get() bool {
 	return v.BoolValue.ValueBool()
 }
 
+// GetPtr returns a pointer to the known int64 value, nil for a
+// null value, or a pointer to 0 for an unknown value.
 func (v *BoolValue) GetPtr() *bool {
 	return v.BoolValue.ValueBoolPointer()
 }
 
+// Set sets the Bool value.
 func (v *BoolValue) Set(s bool) {
 
 	v.BoolValue = basetypes.NewBoolValue(s)
 }
 
+// SetPtr sets a pointer to the Bool value.
 func (v *BoolValue) SetPtr(s *bool) {
 	if s == nil {
 		v.BoolValue = basetypes.NewBoolNull()
@@ -80,14 +85,17 @@ func (v *BoolValue) SetPtr(s *bool) {
 	v.BoolValue = basetypes.NewBoolPointerValue(s)
 }
 
+// SetNull sets the Bool value to null.
 func (v *BoolValue) SetNull() {
 	v.BoolValue = basetypes.NewBoolNull()
 }
 
+// SetUnknown sets the Bool value to unknown.
 func (v *BoolValue) SetUnknown() {
 	v.BoolValue = basetypes.NewBoolUnknown()
 }
 
+// IsKnown returns true if the value is not null and not unknown.
 func (v BoolValue) IsKnown() bool {
 	return !v.BoolValue.IsNull() && !v.BoolValue.IsUnknown()
 }

--- a/float64_type_test.go
+++ b/float64_type_test.go
@@ -137,14 +137,6 @@ func TestFloat64TypeValueFromTerraform(t *testing.T) {
 			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("0.0")),
 			expectation: NewFloat64Value(0.0),
 		},
-		"positive-string-float": {
-			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("123.2")),
-			expectation: NewFloat64Value(123.2),
-		},
-		"negative-string-float": {
-			input:       tftypes.NewValue(tftypes.Number, testMustParseFloat("-123.2")),
-			expectation: NewFloat64Value(-123.2),
-		},
 		// Reference: https://pkg.go.dev/math/big#Float.Float64
 		// Reference: https://pkg.go.dev/math#pkg-constants
 		"SmallestNonzeroFloat64": {

--- a/float64_value.go
+++ b/float64_value.go
@@ -67,7 +67,17 @@ func (v *Float64Value) GetPtr() *float64 {
 }
 
 func (v *Float64Value) Set(s float64) {
+
 	v.Float64Value = basetypes.NewFloat64Value(s)
+}
+
+func (v *Float64Value) SetPtr(s *float64) {
+	if s == nil {
+		v.Float64Value = basetypes.NewFloat64Null()
+		return
+	}
+
+	v.Float64Value = basetypes.NewFloat64PointerValue(s)
 }
 
 func (v *Float64Value) SetNull() {

--- a/float64_value.go
+++ b/float64_value.go
@@ -58,19 +58,24 @@ func NewFloat64PointerValue(s *float64) Float64Value {
 
 // * CustomFunc
 
+// Get returns the known Float64 value. If Float64 is null or unknown, returns 0.0.
 func (v *Float64Value) Get() float64 {
 	return v.Float64Value.ValueFloat64()
 }
 
+// GetPtr returns a pointer to the known int64 value, nil for a
+// null value, or a pointer to 0 for an unknown value.
 func (v *Float64Value) GetPtr() *float64 {
 	return v.Float64Value.ValueFloat64Pointer()
 }
 
+// Set sets the Float64 value.
 func (v *Float64Value) Set(s float64) {
 
 	v.Float64Value = basetypes.NewFloat64Value(s)
 }
 
+// SetPtr sets a pointer to the Float64 value.
 func (v *Float64Value) SetPtr(s *float64) {
 	if s == nil {
 		v.Float64Value = basetypes.NewFloat64Null()
@@ -80,14 +85,75 @@ func (v *Float64Value) SetPtr(s *float64) {
 	v.Float64Value = basetypes.NewFloat64PointerValue(s)
 }
 
+// SetFloat32 sets a converted float32 to float64 value.
+func (v *Float64Value) SetFloat32(s float32) {
+	v.Set(setFloatValue(s))
+}
+
+// SetFloat64 sets a float64 value. This is a same func as Set.
+func (v *Float64Value) SetFloat64(s float64) {
+	v.Set(s)
+}
+
+// SetFloat32Ptr sets a converted float32 to float64 pointer. If the pointer is nil, the value is set to null.
+func (v *Float64Value) SetFloat32Ptr(s *float32) {
+	if s == nil {
+		v.Float64Value = basetypes.NewFloat64Null()
+		return
+	}
+
+	v.Float64Value = basetypes.NewFloat64Value(setFloatValue(*s))
+}
+
+// SetFloat64Ptr sets a float64 pointer. This is a same func as SetPtr.
+func (v *Float64Value) SetFloat64Ptr(s *float64) {
+	v.SetPtr(s)
+}
+
+// GetFloat32 returns converted float64 to float32 value.
+func (v *Float64Value) GetFloat32() float32 {
+	return float32(v.Get())
+}
+
+// GetFloat64 returns the float64 value. This is a same func as Get.
+func (v Float64Value) GetFloat64() float64 {
+	return v.Get()
+}
+
+// GetFloat32Ptr returns a converted float64 to float32 pointer. If the value is null or unknown, nil is returned.
+func (v Float64Value) GetFloat32Ptr() *float32 {
+	if v.IsKnown() {
+		s := float32(v.Get())
+		return &s
+	}
+
+	return nil
+}
+
+// GetFloat64Ptr returns a float64 pointer. This is a same func as GetPtr. If the value is null or unknown, nil is returned.
+func (v Float64Value) GetFloat64Ptr() *float64 {
+	return v.GetPtr()
+}
+
+type floatValues interface {
+	float32 | float64
+}
+
+func setFloatValue[T floatValues](s T) float64 {
+	return float64(s)
+}
+
+// SetNull sets the Float64 value to null.
 func (v *Float64Value) SetNull() {
 	v.Float64Value = basetypes.NewFloat64Null()
 }
 
+// SetUnknown sets the Float64 value to unknown.
 func (v *Float64Value) SetUnknown() {
 	v.Float64Value = basetypes.NewFloat64Unknown()
 }
 
+// IsKnown returns true if the value is not null and not unknown.
 func (v Float64Value) IsKnown() bool {
 	return !v.Float64Value.IsNull() && !v.Float64Value.IsUnknown()
 }

--- a/float64_value_test.go
+++ b/float64_value_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
 )
 
 // testMustParseFloat parses a string into a *big.Float similar to cty and
@@ -390,4 +391,114 @@ func TestNewFloat64PointerValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFloat64Value(t *testing.T) {
+	t.Run("Get", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		assert.Equal(t, 1.23, v.Get())
+	})
+
+	t.Run("GetPtr", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		p := v.GetPtr()
+		assert.NotNil(t, p)
+		assert.Equal(t, 1.23, *p)
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		v.Set(4.56)
+		assert.Equal(t, 4.56, v.Get())
+	})
+
+	t.Run("SetPtr", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		p := float64(4.56)
+		v.SetPtr(&p)
+		assert.Equal(t, 4.56, v.Get())
+
+		v.SetPtr(nil)
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("SetFloat32", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		v.SetFloat32(4.56)
+		assert.Equal(t, float32(4.56), v.GetFloat32())
+	})
+
+	t.Run("SetFloat64", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		v.SetFloat64(4.56)
+		assert.Equal(t, 4.56, v.Get())
+	})
+
+	t.Run("SetFloat32Ptr", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		p := float32(4.56)
+		v.SetFloat32Ptr(&p)
+		assert.Equal(t, float32(4.56), v.GetFloat32())
+
+		v.SetFloat32Ptr(nil)
+		assert.True(t, v.IsNull())
+
+		x := v.GetFloat32Ptr()
+		assert.Nil(t, x)
+	})
+
+	t.Run("SetFloat64Ptr", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		p := float64(4.56)
+		v.SetFloat64Ptr(&p)
+		assert.Equal(t, 4.56, v.Get())
+
+		v.SetFloat64Ptr(nil)
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("GetFloat32", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		assert.Equal(t, float32(1.23), v.GetFloat32())
+	})
+
+	t.Run("GetFloat64", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		assert.Equal(t, 1.23, v.GetFloat64())
+	})
+
+	t.Run("GetFloat32Ptr", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		p := v.GetFloat32Ptr()
+		assert.NotNil(t, p)
+		assert.Equal(t, float32(1.23), *p)
+	})
+
+	t.Run("GetFloat64Ptr", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		p := v.GetFloat64Ptr()
+		assert.NotNil(t, p)
+		assert.Equal(t, 1.23, *p)
+	})
+
+	t.Run("SetNull", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		v.SetNull()
+		assert.True(t, v.Float64Value.IsNull())
+	})
+
+	t.Run("SetUnknown", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		v.SetUnknown()
+		assert.True(t, v.Float64Value.IsUnknown())
+	})
+
+	t.Run("IsKnown", func(t *testing.T) {
+		v := NewFloat64Value(1.23)
+		assert.True(t, v.IsKnown())
+		v.SetNull()
+		assert.False(t, v.IsKnown())
+		v.SetUnknown()
+		assert.False(t, v.IsKnown())
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,16 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.3.5
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/iancoleman/strcase v0.3.0
+	github.com/stretchr/testify v1.6.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	golang.org/x/sys v0.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,7 @@ github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.9.0 h1:KS/R3tvhPqvJvwcKfnBHJwwthS11LRhmM5D59eEXa0s=
 golang.org/x/sys v0.9.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/int64_value.go
+++ b/int64_value.go
@@ -58,19 +58,24 @@ func NewInt64PointerValue(s *int64) Int64Value {
 
 // * CustomFunc
 
+// Get returns the known Int64 value. If Int64 is null or unknown, returns 0.
 func (v *Int64Value) Get() int64 {
 	return v.Int64Value.ValueInt64()
 }
 
+// GetPtr returns a pointer to the known int64 value, nil for a
+// null value, or a pointer to 0 for an unknown value.
 func (v *Int64Value) GetPtr() *int64 {
 	return v.Int64Value.ValueInt64Pointer()
 }
 
+// Set sets the Int64 value.
 func (v *Int64Value) Set(s int64) {
 
 	v.Int64Value = basetypes.NewInt64Value(s)
 }
 
+// SetPtr sets a pointer to the Int64 value.
 func (v *Int64Value) SetPtr(s *int64) {
 	if s == nil {
 		v.Int64Value = basetypes.NewInt64Null()
@@ -80,66 +85,98 @@ func (v *Int64Value) SetPtr(s *int64) {
 	v.Int64Value = basetypes.NewInt64PointerValue(s)
 }
 
-func (v Int64Value) SetInt(s int) {
-	v.Int64Value = basetypes.NewInt64Value(int64(s))
+// SetInt sets the int64 value to the given int.
+func (v *Int64Value) SetInt(s int) {
+	v.Set(setIntValue(s))
 }
 
-func (v Int64Value) SetInt8(s int8) {
-	v.Int64Value = basetypes.NewInt64Value(int64(s))
+// SetInt8 sets the int64 value to the given int8.
+func (v *Int64Value) SetInt8(s int8) {
+	v.Set(setIntValue(s))
 }
 
-func (v Int64Value) SetInt16(s int16) {
-	v.Int64Value = basetypes.NewInt64Value(int64(s))
+// SetInt16 sets the int64 value to the given int16.
+func (v *Int64Value) SetInt16(s int16) {
+	v.Set(setIntValue(s))
 }
 
-func (v Int64Value) SetInt32(s int32) {
-	v.Int64Value = basetypes.NewInt64Value(int64(s))
+// SetInt32 Sets the int64 value to the given int32.
+func (v *Int64Value) SetInt32(s int32) {
+	v.Set(setIntValue(s))
 }
 
-func (v Int64Value) SetInt64(s int64) {
+// SetInt64 sets the int64 value to the given int64. This is a same func as Set.
+func (v *Int64Value) SetInt64(s int64) {
 	v.Set(s)
 }
 
-func (v Int64Value) SetIntPtr(s *int) {
-	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+// SetIntPtr sets the int64 value to the given int pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetIntPtr(s *int) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
 }
 
-func (v Int64Value) SetInt8Ptr(s *int8) {
-	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+// SetInt8Ptr sets the int64 value to the given int8 pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetInt8Ptr(s *int8) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
 }
 
-func (v Int64Value) SetInt16Ptr(s *int16) {
-	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+// SetInt16Ptr sets the int64 value to the given int16 pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetInt16Ptr(s *int16) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
 }
 
-func (v Int64Value) SetInt32Ptr(s *int32) {
-	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+// SetInt32Ptr sets the int64 value to the given int32 pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetInt32Ptr(s *int32) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
 }
 
-func (v Int64Value) SetInt64Ptr(s *int64) {
+// SetInt64Ptr sets the int64 value to the given int64 pointer.
+func (v *Int64Value) SetInt64Ptr(s *int64) {
 	v.SetPtr(s)
 }
 
+// GetInt returns converted int64 to int value.
 func (v Int64Value) GetInt() int {
 	return int(v.Get())
 }
 
+// GetInt8 return converted int64 to int8 value.
 func (v Int64Value) GetInt8() int8 {
 	return int8(v.Get())
 }
 
+// GetInt16 return converted int64 to int16 value.
 func (v Int64Value) GetInt16() int16 {
 	return int16(v.Get())
 }
 
+// GetInt32 returns converted int64 to int32 value.
 func (v Int64Value) GetInt32() int32 {
 	return int32(v.Get())
 }
 
+// GetInt64 returns int64 value. This is a same func as Get.
 func (v Int64Value) GetInt64() int64 {
 	return v.Get()
 }
 
+// GetIntPtr returns a converted int64 to int pointer. If the value is null or unknown, nil is returned.
 func (v Int64Value) GetIntPtr() *int {
 	if v.IsKnown() {
 		i := int(v.Get())
@@ -149,6 +186,7 @@ func (v Int64Value) GetIntPtr() *int {
 	return nil
 }
 
+// GetInt8Ptr returns a converted int64 to int8 pointer. If the value is null or unknown, nil is returned.
 func (v Int64Value) GetInt8Ptr() *int8 {
 	if v.IsKnown() {
 		i := int8(v.Get())
@@ -158,6 +196,7 @@ func (v Int64Value) GetInt8Ptr() *int8 {
 	return nil
 }
 
+// GetInt16Ptr returns a converted int64 to int16 pointer. If the value is null or unknown, nil is returned.
 func (v Int64Value) GetInt16Ptr() *int16 {
 	if v.IsKnown() {
 		i := int16(v.Get())
@@ -167,6 +206,7 @@ func (v Int64Value) GetInt16Ptr() *int16 {
 	return nil
 }
 
+// GetInt32Ptr returns a converted int64 to int32 pointer. If the value is null or unknown, nil is returned.
 func (v Int64Value) GetInt32Ptr() *int32 {
 	if v.IsKnown() {
 		i := int32(v.Get())
@@ -176,6 +216,7 @@ func (v Int64Value) GetInt32Ptr() *int32 {
 	return nil
 }
 
+// GetInt64Ptr returns a pointer to the underlying int64 value.
 func (v Int64Value) GetInt64Ptr() *int64 {
 	if v.IsKnown() {
 		i := v.Get()
@@ -185,14 +226,25 @@ func (v Int64Value) GetInt64Ptr() *int64 {
 	return nil
 }
 
+type intValues interface {
+	int | int8 | int16 | int32 | int64
+}
+
+func setIntValue[T intValues](s T) int64 {
+	return int64(s)
+}
+
+// SetNull sets the Int64 value to null.
 func (v *Int64Value) SetNull() {
 	v.Int64Value = basetypes.NewInt64Null()
 }
 
+// SetUnknown sets the Int64 value to unknown.
 func (v *Int64Value) SetUnknown() {
 	v.Int64Value = basetypes.NewInt64Unknown()
 }
 
+// IsKnown returns true if the value is not null and not unknown.
 func (v Int64Value) IsKnown() bool {
 	return !v.Int64Value.IsNull() && !v.Int64Value.IsUnknown()
 }

--- a/int64_value.go
+++ b/int64_value.go
@@ -67,7 +67,122 @@ func (v *Int64Value) GetPtr() *int64 {
 }
 
 func (v *Int64Value) Set(s int64) {
+
 	v.Int64Value = basetypes.NewInt64Value(s)
+}
+
+func (v *Int64Value) SetPtr(s *int64) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+
+	v.Int64Value = basetypes.NewInt64PointerValue(s)
+}
+
+func (v Int64Value) SetInt(s int) {
+	v.Int64Value = basetypes.NewInt64Value(int64(s))
+}
+
+func (v Int64Value) SetInt8(s int8) {
+	v.Int64Value = basetypes.NewInt64Value(int64(s))
+}
+
+func (v Int64Value) SetInt16(s int16) {
+	v.Int64Value = basetypes.NewInt64Value(int64(s))
+}
+
+func (v Int64Value) SetInt32(s int32) {
+	v.Int64Value = basetypes.NewInt64Value(int64(s))
+}
+
+func (v Int64Value) SetInt64(s int64) {
+	v.Set(s)
+}
+
+func (v Int64Value) SetIntPtr(s *int) {
+	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+}
+
+func (v Int64Value) SetInt8Ptr(s *int8) {
+	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+}
+
+func (v Int64Value) SetInt16Ptr(s *int16) {
+	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+}
+
+func (v Int64Value) SetInt32Ptr(s *int32) {
+	v.Int64Value = basetypes.NewInt64PointerValue(int64(s))
+}
+
+func (v Int64Value) SetInt64Ptr(s *int64) {
+	v.SetPtr(s)
+}
+
+func (v Int64Value) GetInt() int {
+	return int(v.Get())
+}
+
+func (v Int64Value) GetInt8() int8 {
+	return int8(v.Get())
+}
+
+func (v Int64Value) GetInt16() int16 {
+	return int16(v.Get())
+}
+
+func (v Int64Value) GetInt32() int32 {
+	return int32(v.Get())
+}
+
+func (v Int64Value) GetInt64() int64 {
+	return v.Get()
+}
+
+func (v Int64Value) GetIntPtr() *int {
+	if v.IsKnown() {
+		i := int(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v Int64Value) GetInt8Ptr() *int8 {
+	if v.IsKnown() {
+		i := int8(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v Int64Value) GetInt16Ptr() *int16 {
+	if v.IsKnown() {
+		i := int16(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v Int64Value) GetInt32Ptr() *int32 {
+	if v.IsKnown() {
+		i := int32(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v Int64Value) GetInt64Ptr() *int64 {
+	if v.IsKnown() {
+		i := v.Get()
+		return &i
+	}
+
+	return nil
 }
 
 func (v *Int64Value) SetNull() {

--- a/int64_value_test.go
+++ b/int64_value_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInt64ValueToTerraformValue(t *testing.T) {
@@ -348,4 +349,246 @@ func TestNewInt64PointerValue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInt64Value(t *testing.T) {
+	// Test NewInt64Null
+	v := NewInt64Null()
+	assert.True(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.False(t, v.IsKnown())
+	assert.Equal(t, int64(0), v.Get())
+
+	// Test NewInt64Unknown
+	v = NewInt64Unknown()
+	assert.False(t, v.IsNull())
+	assert.True(t, v.IsUnknown())
+	assert.False(t, v.IsKnown())
+	assert.Equal(t, int64(0), v.Get())
+
+	// Test NewInt64Value
+	v = NewInt64Value(42)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(42), v.Get())
+
+	// Test NewInt64PointerValue
+	i := int64(42)
+	v = NewInt64PointerValue(&i)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(42), v.Get())
+
+	// Test Set
+	v.Set(84)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(84), v.Get())
+
+	// Test SetPtr
+	i = 168
+	v.SetPtr(&i)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(168), v.Get())
+
+	// Test SetInt
+	v.SetInt(42)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(42), v.Get())
+
+	// Test SetInt8
+	v.SetInt8(8)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(8), v.Get())
+
+	// Test SetInt16
+	v.SetInt16(16)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(16), v.Get())
+
+	// Test SetInt32
+	v.SetInt32(32)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(32), v.Get())
+
+	// Test SetInt64
+	v.SetInt64(64)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(64), v.Get())
+
+	// Test SetIntPtr
+	iInt := int(128)
+	v.SetIntPtr(&iInt)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(128), v.Get())
+	assert.NotNil(t, v.GetIntPtr())
+
+	// Test SetInt8Ptr
+	i8 := int8(8)
+	v.SetInt8Ptr(&i8)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(8), v.Get())
+	assert.NotNil(t, v.GetInt8Ptr())
+
+	// Test SetInt16Ptr
+	i16 := int16(16)
+	v.SetInt16Ptr(&i16)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(16), v.Get())
+	assert.NotNil(t, v.GetInt16Ptr())
+
+	// Test SetInt32Ptr
+	i32 := int32(32)
+	v.SetInt32Ptr(&i32)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(32), v.Get())
+	assert.NotNil(t, v.GetInt32Ptr())
+
+	// Test SetInt64Ptr
+	i64 := int64(64)
+	v.SetInt64Ptr(&i64)
+	assert.False(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.True(t, v.IsKnown())
+	assert.Equal(t, int64(64), v.Get())
+	assert.NotNil(t, v.GetInt64Ptr())
+
+	// Test GetPtr
+	iPtr := v.GetPtr()
+	assert.NotNil(t, iPtr)
+	assert.Equal(t, int64(64), *iPtr)
+
+	// Test GetInt
+	assert.Equal(t, 64, v.GetInt())
+
+	// Test GetInt8
+	assert.Equal(t, int8(64), v.GetInt8())
+
+	// Test GetInt16
+	assert.Equal(t, int16(64), v.GetInt16())
+
+	// Test GetInt32
+	assert.Equal(t, int32(64), v.GetInt32())
+
+	// Test GetInt64
+	assert.Equal(t, int64(64), v.GetInt64())
+
+	// Test GetIntPtr
+	iIntPtr := v.GetIntPtr()
+	assert.NotNil(t, iIntPtr)
+	assert.Equal(t, 64, *iIntPtr)
+
+	// Test GetInt8Ptr
+	i8Ptr := v.GetInt8Ptr()
+	assert.NotNil(t, i8Ptr)
+	assert.Equal(t, int8(64), *i8Ptr)
+
+	// Test GetInt16Ptr
+	i16Ptr := v.GetInt16Ptr()
+	assert.NotNil(t, i16Ptr)
+	assert.Equal(t, int16(64), *i16Ptr)
+
+	// Test GetInt32Ptr
+	i32Ptr := v.GetInt32Ptr()
+	assert.NotNil(t, i32Ptr)
+	assert.Equal(t, int32(64), *i32Ptr)
+
+	// Test GetInt64Ptr
+	i64Ptr := v.GetInt64Ptr()
+	assert.NotNil(t, i64Ptr)
+	assert.Equal(t, int64(64), *i64Ptr)
+
+	v.SetNull()
+
+	// Test GetPtr is nil
+	iPtr = v.GetPtr()
+	assert.Nil(t, iPtr)
+
+	// Test GetIntPtr is nil
+	iIntPtr = v.GetIntPtr()
+	assert.Nil(t, iIntPtr)
+
+	// Test GetInt8Ptr is nil
+	i8Ptr = v.GetInt8Ptr()
+	assert.Nil(t, i8Ptr)
+
+	// Test GetInt16Ptr is nil
+	i16Ptr = v.GetInt16Ptr()
+	assert.Nil(t, i16Ptr)
+
+	// Test GetInt32Ptr is nil
+	i32Ptr = v.GetInt32Ptr()
+	assert.Nil(t, i32Ptr)
+
+	// Test GetInt64Ptr is nil
+	i64Ptr = v.GetInt64Ptr()
+	assert.Nil(t, i64Ptr)
+
+	// Set Ptr to nil
+	v.SetPtr(nil)
+	assert.True(t, v.IsNull())
+
+	// Set IntPtr to nil
+	v.SetIntPtr(nil)
+	assert.True(t, v.IsNull())
+
+	// Set Int8Ptr to nil
+	v.SetInt8Ptr(nil)
+	assert.True(t, v.IsNull())
+
+	// Set Int16Ptr to nil
+	v.SetInt16Ptr(nil)
+	assert.True(t, v.IsNull())
+
+	// Set Int32Ptr to nil
+	v.SetInt32Ptr(nil)
+	assert.True(t, v.IsNull())
+
+	// Set Int64Ptr to nil
+	v.SetInt64Ptr(nil)
+	assert.True(t, v.IsNull())
+
+	// Test SetNull
+	v.SetNull()
+	assert.True(t, v.IsNull())
+	assert.False(t, v.IsUnknown())
+	assert.False(t, v.IsKnown())
+	assert.Equal(t, int64(0), v.Get())
+
+	// Test SetUnknown
+	v.SetUnknown()
+	assert.False(t, v.IsNull())
+	assert.True(t, v.IsUnknown())
+	assert.False(t, v.IsKnown())
+	assert.Equal(t, int64(0), v.Get())
+
+	// Test Equal
+	v1 := NewInt64Value(42)
+	v2 := NewInt64Value(42)
+	v3 := NewInt64Value(84)
+	assert.True(t, v1.Equal(v2))
+	assert.False(t, v1.Equal(v3))
 }

--- a/number_value.go
+++ b/number_value.go
@@ -59,7 +59,17 @@ func (v *NumberValue) Get() *big.Float {
 }
 
 func (v *NumberValue) Set(s *big.Float) {
+
 	v.NumberValue = basetypes.NewNumberValue(s)
+}
+
+func (v *NumberValue) SetPtr(s **big.Float) {
+	if s == nil {
+		v.NumberValue = basetypes.NewNumberNull()
+		return
+	}
+
+	v.NumberValue = basetypes.NewNumberPointerValue(s)
 }
 
 func (v *NumberValue) SetNull() {

--- a/number_value.go
+++ b/number_value.go
@@ -54,32 +54,28 @@ func NewNumberValue(s *big.Float) NumberValue {
 
 // * CustomFunc
 
+// Get returns the known Number value. If Number is null or unknown, returns 0.0.
 func (v *NumberValue) Get() *big.Float {
 	return v.NumberValue.ValueBigFloat()
 }
 
+// Set sets the Number value.
 func (v *NumberValue) Set(s *big.Float) {
 
 	v.NumberValue = basetypes.NewNumberValue(s)
 }
 
-func (v *NumberValue) SetPtr(s **big.Float) {
-	if s == nil {
-		v.NumberValue = basetypes.NewNumberNull()
-		return
-	}
-
-	v.NumberValue = basetypes.NewNumberPointerValue(s)
-}
-
+// SetNull sets the Number value to null.
 func (v *NumberValue) SetNull() {
 	v.NumberValue = basetypes.NewNumberNull()
 }
 
+// SetUnknown sets the Number value to unknown.
 func (v *NumberValue) SetUnknown() {
 	v.NumberValue = basetypes.NewNumberUnknown()
 }
 
+// IsKnown returns true if the value is not null and not unknown.
 func (v NumberValue) IsKnown() bool {
 	return !v.NumberValue.IsNull() && !v.NumberValue.IsUnknown()
 }

--- a/string_value.go
+++ b/string_value.go
@@ -58,14 +58,18 @@ func NewStringPointerValue(s *string) StringValue {
 
 // * CustomFunc
 
+// Get returns the known String value. If String is null or unknown, returns "".
 func (v *StringValue) Get() string {
 	return v.StringValue.ValueString()
 }
 
+// GetPtr returns a pointer to the known int64 value, nil for a
+// null value, or a pointer to 0 for an unknown value.
 func (v *StringValue) GetPtr() *string {
 	return v.StringValue.ValueStringPointer()
 }
 
+// Set sets the String value.
 func (v *StringValue) Set(s string) {
 
 	if s == "" {
@@ -76,6 +80,7 @@ func (v *StringValue) Set(s string) {
 	v.StringValue = basetypes.NewStringValue(s)
 }
 
+// SetPtr sets a pointer to the String value.
 func (v *StringValue) SetPtr(s *string) {
 	if s == nil {
 		v.StringValue = basetypes.NewStringNull()
@@ -85,14 +90,17 @@ func (v *StringValue) SetPtr(s *string) {
 	v.StringValue = basetypes.NewStringPointerValue(s)
 }
 
+// SetNull sets the String value to null.
 func (v *StringValue) SetNull() {
 	v.StringValue = basetypes.NewStringNull()
 }
 
+// SetUnknown sets the String value to unknown.
 func (v *StringValue) SetUnknown() {
 	v.StringValue = basetypes.NewStringUnknown()
 }
 
+// IsKnown returns true if the value is not null and not unknown.
 func (v StringValue) IsKnown() bool {
 	return !v.StringValue.IsNull() && !v.StringValue.IsUnknown()
 }

--- a/string_value.go
+++ b/string_value.go
@@ -67,7 +67,22 @@ func (v *StringValue) GetPtr() *string {
 }
 
 func (v *StringValue) Set(s string) {
+
+	if s == "" {
+		v.StringValue = basetypes.NewStringNull()
+		return
+	}
+
 	v.StringValue = basetypes.NewStringValue(s)
+}
+
+func (v *StringValue) SetPtr(s *string) {
+	if s == nil {
+		v.StringValue = basetypes.NewStringNull()
+		return
+	}
+
+	v.StringValue = basetypes.NewStringPointerValue(s)
 }
 
 func (v *StringValue) SetNull() {

--- a/string_value_test.go
+++ b/string_value_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringValueToTerraformValue(t *testing.T) {
@@ -341,5 +342,123 @@ func TestNewStringPointerValue(t *testing.T) {
 				t.Errorf("unexpected difference: %s", diff)
 			}
 		})
+	}
+}
+
+func TestStringValue(t *testing.T) {
+	t.Run("Get", func(t *testing.T) {
+		v := NewStringValue("hello")
+		assert.Equal(t, "hello", v.Get())
+	})
+
+	t.Run("GetPtr", func(t *testing.T) {
+		v := NewStringValue("hello")
+		ptr := v.GetPtr()
+		assert.NotNil(t, ptr)
+		assert.Equal(t, "hello", *ptr)
+
+		v.SetNull()
+		ptr = v.GetPtr()
+		assert.Nil(t, ptr)
+
+		v.SetUnknown()
+		ptr = v.GetPtr()
+		assert.NotNil(t, ptr)
+		assert.Equal(t, "", *ptr)
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		v := NewStringValue("hello")
+		assert.Equal(t, "hello", v.Get())
+
+		v.Set("world")
+		assert.Equal(t, "world", v.Get())
+
+		v.Set("")
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("SetPtr", func(t *testing.T) {
+		v := NewStringValue("hello")
+		assert.Equal(t, "hello", v.Get())
+
+		ptr := "world"
+		v.SetPtr(&ptr)
+		assert.Equal(t, "world", v.Get())
+
+		v.SetPtr(nil)
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("SetNull", func(t *testing.T) {
+		v := NewStringValue("hello")
+		assert.False(t, v.IsNull())
+
+		v.SetNull()
+		assert.True(t, v.IsNull())
+	})
+
+	t.Run("SetUnknown", func(t *testing.T) {
+		v := NewStringValue("hello")
+		assert.False(t, v.IsUnknown())
+
+		v.SetUnknown()
+		assert.True(t, v.IsUnknown())
+	})
+}
+
+func TestStringValueIsKnown(t *testing.T) {
+	// Test NewStringValue
+	s := "hello"
+	v := NewStringValue(s)
+	if v.Get() != s {
+		t.Errorf("Expected %q, got %q", s, v.Get())
+	}
+
+	// Test NewStringPointerValue
+	sp := &s
+	v = NewStringPointerValue(sp)
+	if v.Get() != s {
+		t.Errorf("Expected %q, got %q", s, v.Get())
+	}
+
+	// Test Set
+	s2 := "world"
+	v.Set(s2)
+	if v.Get() != s2 {
+		t.Errorf("Expected %q, got %q", s2, v.Get())
+	}
+
+	// Test SetPtr
+	sp2 := &s2
+	v.SetPtr(sp2)
+	if v.Get() != s2 {
+		t.Errorf("Expected %q, got %q", s2, v.Get())
+	}
+
+	// Test SetNull
+	v.SetNull()
+	if v.Get() != "" {
+		t.Errorf("Expected empty string, got %q", v.Get())
+	}
+
+	// Test SetUnknown
+	v.SetUnknown()
+	if v.Get() != "" {
+		t.Errorf("Expected empty string, got %q", v.Get())
+	}
+
+	// Test IsKnown
+	v.Set(s)
+	if !v.IsKnown() {
+		t.Errorf("Expected IsKnown to be true, got false")
+	}
+	v.SetNull()
+	if v.IsKnown() {
+		t.Errorf("Expected IsKnown to be false, got true")
+	}
+	v.SetUnknown()
+	if v.IsKnown() {
+		t.Errorf("Expected IsKnown to be false, got true")
 	}
 }

--- a/templates/simple_value.go.tmpl
+++ b/templates/simple_value.go.tmpl
@@ -72,8 +72,132 @@ func (v *{{ .TypeName }}Value) GetPtr() *{{ golangType .TypeName }} {
 {{ end }}
 
 func (v *{{ .TypeName }}Value) Set(s {{ golangType .TypeName }}) {
+	{{ if eq .TypeName "String" }}
+	if s == "" {
+		v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Null()
+		return
+	}
+	{{ end }}
 	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(s)
 }
+
+func (v *{{ .TypeName }}Value) SetPtr(s *{{ golangType .TypeName }}) {
+	if s == nil {
+		v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Null()
+		return
+	}
+	
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(s)
+}
+
+{{ if eq .TypeName "Int64" }}
+func (v {{ .TypeName }}Value) SetInt(s int) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
+}
+
+func (v {{ .TypeName }}Value) SetInt8(s int8) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
+}
+
+func (v {{ .TypeName }}Value) SetInt16(s int16) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
+}
+
+func (v {{ .TypeName }}Value) SetInt32(s int32) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
+}
+
+func (v {{ .TypeName }}Value) Set{{ .TypeName }}(s int64) {
+	v.Set(s)
+}
+
+func (v {{ .TypeName }}Value) SetIntPtr(s *int) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
+}
+
+func (v {{ .TypeName }}Value) SetInt8Ptr(s *int8) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
+}
+
+func (v {{ .TypeName }}Value) SetInt16Ptr(s *int16) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
+}
+
+func (v {{ .TypeName }}Value) SetInt32Ptr(s *int32) {
+	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
+}
+
+func (v {{ .TypeName }}Value) Set{{ .TypeName }}Ptr(s *int64) {
+	v.SetPtr(s)
+}
+
+
+func (v {{ .TypeName }}Value) GetInt() int {
+	return int(v.Get())
+}
+
+func (v {{ .TypeName }}Value) GetInt8() int8 {
+	return int8(v.Get())
+}
+
+func (v {{ .TypeName }}Value) GetInt16() int16 {
+	return int16(v.Get())
+}
+
+func (v {{ .TypeName }}Value) GetInt32() int32 {
+	return int32(v.Get())
+}
+
+func (v {{ .TypeName }}Value) GetInt64() int64 {
+	return v.Get()
+}
+
+func (v {{ .TypeName }}Value) GetIntPtr() *int {
+	if v.IsKnown() {
+		i := int(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v {{ .TypeName }}Value) GetInt8Ptr() *int8 {
+	if v.IsKnown() {
+		i := int8(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v {{ .TypeName }}Value) GetInt16Ptr() *int16 {
+	if v.IsKnown() {
+		i := int16(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v {{ .TypeName }}Value) GetInt32Ptr() *int32 {
+	if v.IsKnown() {
+		i := int32(v.Get())
+		return &i
+	}
+
+	return nil
+}
+
+func (v {{ .TypeName }}Value) GetInt64Ptr() *int64 {
+	if v.IsKnown() {
+		i := v.Get()
+		return &i
+	}
+
+	return nil
+}
+
+{{ end }}
 
 func (v *{{ .TypeName }}Value) SetNull() {
 	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Null()

--- a/templates/simple_value.go.tmpl
+++ b/templates/simple_value.go.tmpl
@@ -61,16 +61,25 @@ func New{{ .TypeName }}PointerValue(s *{{ golangType .TypeName }}) {{ .TypeName 
 
 // * CustomFunc
 
+// Get returns the known {{ .TypeName }} value.
+{{- if eq .TypeName "Int64" }} If Int64 is null or unknown, returns 0.{{ end }}
+{{- if eq .TypeName "Float64" }} If Float64 is null or unknown, returns 0.0.{{ end }}
+{{- if eq .TypeName "String" }} If String is null or unknown, returns "".{{ end }}
+{{- if eq .TypeName "Bool" }} If Bool is null or unknown, returns false.{{ end }}
+{{- if eq .TypeName "Number" }} If Number is null or unknown, returns 0.0.{{ end }}
 func (v *{{ .TypeName }}Value) Get() {{ golangType .TypeName }} {
 	return v.{{ .TypeName }}Value.Value{{  if eq .TypeName "Number"}}BigFloat{{else}}{{ .TypeName }}{{end}}()
 }
 
 {{ if ne .TypeName "Number" }}
+// GetPtr returns a pointer to the known int64 value, nil for a
+// null value, or a pointer to 0 for an unknown value.
 func (v *{{ .TypeName }}Value) GetPtr() *{{ golangType .TypeName }} {
 	return v.{{ .TypeName }}Value.Value{{ .TypeName }}Pointer()
 }
 {{ end }}
 
+// Set sets the {{ .TypeName }} value.
 func (v *{{ .TypeName }}Value) Set(s {{ golangType .TypeName }}) {
 	{{ if eq .TypeName "String" }}
 	if s == "" {
@@ -81,6 +90,8 @@ func (v *{{ .TypeName }}Value) Set(s {{ golangType .TypeName }}) {
 	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(s)
 }
 
+{{ if ne .TypeName "Number" }}
+// SetPtr sets a pointer to the {{ .TypeName }} value.
 func (v *{{ .TypeName }}Value) SetPtr(s *{{ golangType .TypeName }}) {
 	if s == nil {
 		v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Null()
@@ -89,70 +100,163 @@ func (v *{{ .TypeName }}Value) SetPtr(s *{{ golangType .TypeName }}) {
 	
 	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(s)
 }
+{{ end }}
 
-{{ if eq .TypeName "Int64" }}
-func (v {{ .TypeName }}Value) SetInt(s int) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
+{{ if eq .TypeName "Float64" }}
+
+// SetFloat32 sets a converted float32 to float64 value.
+func (v *Float64Value) SetFloat32(s float32) {
+	v.Set(setFloatValue(s))
 }
 
-func (v {{ .TypeName }}Value) SetInt8(s int8) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
-}
-
-func (v {{ .TypeName }}Value) SetInt16(s int16) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
-}
-
-func (v {{ .TypeName }}Value) SetInt32(s int32) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Value(int64(s))
-}
-
-func (v {{ .TypeName }}Value) Set{{ .TypeName }}(s int64) {
+// SetFloat64 sets a float64 value. This is a same func as Set.
+func (v *Float64Value) SetFloat64(s float64) {
 	v.Set(s)
 }
 
-func (v {{ .TypeName }}Value) SetIntPtr(s *int) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
+// SetFloat32Ptr sets a converted float32 to float64 pointer. If the pointer is nil, the value is set to null.
+func (v *Float64Value) SetFloat32Ptr(s *float32) {
+	if s == nil {
+		v.Float64Value = basetypes.NewFloat64Null()
+		return
+	}
+
+	v.Float64Value = basetypes.NewFloat64Value(setFloatValue(*s))
 }
 
-func (v {{ .TypeName }}Value) SetInt8Ptr(s *int8) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
-}
-
-func (v {{ .TypeName }}Value) SetInt16Ptr(s *int16) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
-}
-
-func (v {{ .TypeName }}Value) SetInt32Ptr(s *int32) {
-	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}PointerValue(int64(s))
-}
-
-func (v {{ .TypeName }}Value) Set{{ .TypeName }}Ptr(s *int64) {
+// SetFloat64Ptr sets a float64 pointer. This is a same func as SetPtr.
+func (v *Float64Value) SetFloat64Ptr(s *float64) {
 	v.SetPtr(s)
 }
 
-
-func (v {{ .TypeName }}Value) GetInt() int {
-	return int(v.Get())
+// GetFloat32 returns converted float64 to float32 value.
+func (v *Float64Value) GetFloat32() float32 {
+	return float32(v.Get())
 }
 
-func (v {{ .TypeName }}Value) GetInt8() int8 {
-	return int8(v.Get())
-}
-
-func (v {{ .TypeName }}Value) GetInt16() int16 {
-	return int16(v.Get())
-}
-
-func (v {{ .TypeName }}Value) GetInt32() int32 {
-	return int32(v.Get())
-}
-
-func (v {{ .TypeName }}Value) GetInt64() int64 {
+// GetFloat64 returns the float64 value. This is a same func as Get.
+func (v Float64Value) GetFloat64() float64 {
 	return v.Get()
 }
 
-func (v {{ .TypeName }}Value) GetIntPtr() *int {
+// GetFloat32Ptr returns a converted float64 to float32 pointer. If the value is null or unknown, nil is returned.
+func (v Float64Value) GetFloat32Ptr() *float32 {
+	if v.IsKnown() {
+		s := float32(v.Get())
+		return &s
+	}
+
+	return nil
+}
+
+// GetFloat64Ptr returns a float64 pointer. This is a same func as GetPtr. If the value is null or unknown, nil is returned.
+func (v Float64Value) GetFloat64Ptr() *float64 {
+	return v.GetPtr()
+}
+
+type floatValues interface {
+	float32 | float64
+}
+
+func setFloatValue[T floatValues](s T) float64 {
+	return float64(s)
+}
+{{ end }}
+
+{{ if eq .TypeName "Int64" }}
+// SetInt sets the int64 value to the given int.
+func (v *Int64Value) SetInt(s int) {
+	v.Set(setIntValue(s))
+}
+
+// SetInt8 sets the int64 value to the given int8.
+func (v *Int64Value) SetInt8(s int8) {
+	v.Set(setIntValue(s))
+}
+
+// SetInt16 sets the int64 value to the given int16.
+func (v *Int64Value) SetInt16(s int16) {
+	v.Set(setIntValue(s))
+}
+
+// SetInt32 Sets the int64 value to the given int32.
+func (v *Int64Value) SetInt32(s int32) {
+	v.Set(setIntValue(s))
+}
+
+// SetInt64 sets the int64 value to the given int64. This is a same func as Set.
+func (v *Int64Value) SetInt64(s int64) {
+	v.Set(s)
+}
+
+// SetIntPtr sets the int64 value to the given int pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetIntPtr(s *int) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
+}
+
+// SetInt8Ptr sets the int64 value to the given int8 pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetInt8Ptr(s *int8) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
+}
+
+// SetInt16Ptr sets the int64 value to the given int16 pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetInt16Ptr(s *int16) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
+}
+
+// SetInt32Ptr sets the int64 value to the given int32 pointer. If the pointer is nil, the value is set to null.
+func (v *Int64Value) SetInt32Ptr(s *int32) {
+	if s == nil {
+		v.Int64Value = basetypes.NewInt64Null()
+		return
+	}
+	v.Int64Value = basetypes.NewInt64Value(setIntValue(*s))
+}
+
+// SetInt64Ptr sets the int64 value to the given int64 pointer.
+func (v *Int64Value) SetInt64Ptr(s *int64) {
+	v.SetPtr(s)
+}
+
+// GetInt returns converted int64 to int value.
+func (v Int64Value) GetInt() int {
+	return int(v.Get())
+}
+
+// GetInt8 return converted int64 to int8 value.
+func (v Int64Value) GetInt8() int8 {
+	return int8(v.Get())
+}
+
+// GetInt16 return converted int64 to int16 value.
+func (v Int64Value) GetInt16() int16 {
+	return int16(v.Get())
+}
+
+// GetInt32 returns converted int64 to int32 value.
+func (v Int64Value) GetInt32() int32 {
+	return int32(v.Get())
+}
+
+// GetInt64 returns int64 value. This is a same func as Get.
+func (v Int64Value) GetInt64() int64 {
+	return v.Get()
+}
+
+// GetIntPtr returns a converted int64 to int pointer. If the value is null or unknown, nil is returned.
+func (v Int64Value) GetIntPtr() *int {
 	if v.IsKnown() {
 		i := int(v.Get())
 		return &i
@@ -161,7 +265,8 @@ func (v {{ .TypeName }}Value) GetIntPtr() *int {
 	return nil
 }
 
-func (v {{ .TypeName }}Value) GetInt8Ptr() *int8 {
+// GetInt8Ptr returns a converted int64 to int8 pointer. If the value is null or unknown, nil is returned.
+func (v Int64Value) GetInt8Ptr() *int8 {
 	if v.IsKnown() {
 		i := int8(v.Get())
 		return &i
@@ -170,7 +275,8 @@ func (v {{ .TypeName }}Value) GetInt8Ptr() *int8 {
 	return nil
 }
 
-func (v {{ .TypeName }}Value) GetInt16Ptr() *int16 {
+// GetInt16Ptr returns a converted int64 to int16 pointer. If the value is null or unknown, nil is returned.
+func (v Int64Value) GetInt16Ptr() *int16 {
 	if v.IsKnown() {
 		i := int16(v.Get())
 		return &i
@@ -179,7 +285,8 @@ func (v {{ .TypeName }}Value) GetInt16Ptr() *int16 {
 	return nil
 }
 
-func (v {{ .TypeName }}Value) GetInt32Ptr() *int32 {
+// GetInt32Ptr returns a converted int64 to int32 pointer. If the value is null or unknown, nil is returned.
+func (v Int64Value) GetInt32Ptr() *int32 {
 	if v.IsKnown() {
 		i := int32(v.Get())
 		return &i
@@ -188,7 +295,8 @@ func (v {{ .TypeName }}Value) GetInt32Ptr() *int32 {
 	return nil
 }
 
-func (v {{ .TypeName }}Value) GetInt64Ptr() *int64 {
+// GetInt64Ptr returns a pointer to the underlying int64 value.
+func (v Int64Value) GetInt64Ptr() *int64 {
 	if v.IsKnown() {
 		i := v.Get()
 		return &i
@@ -197,16 +305,28 @@ func (v {{ .TypeName }}Value) GetInt64Ptr() *int64 {
 	return nil
 }
 
+type intValues interface {
+	int | int8 | int16 | int32 | int64
+}
+
+func setIntValue[T intValues](s T) int64 {
+	return int64(s)
+}
+
+
 {{ end }}
 
+// SetNull sets the {{ .TypeName }} value to null.
 func (v *{{ .TypeName }}Value) SetNull() {
 	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Null()
 }
 
+// SetUnknown sets the {{ .TypeName }} value to unknown.
 func (v *{{ .TypeName }}Value) SetUnknown() {
 	v.{{ .TypeName }}Value = basetypes.New{{ .TypeName }}Unknown()
 }
 
+// IsKnown returns true if the value is not null and not unknown.
 func (v {{ .TypeName }}Value) IsKnown() bool {
 	return !v.{{ .TypeName }}Value.IsNull() && !v.{{ .TypeName }}Value.IsUnknown()
 }


### PR DESCRIPTION
## Description
This pull request adds new functions to the `attribute/int64`, `attribute/float64`, `attribute/string`, and `attribute/bool` types. It also includes a breaking change to the `attribute/string` type's `Set` function.

## Changes Made
- Added the following functions to the `attribute/int64` type:
    - `SetPtr`
    - `SetInt`
    - `SetInt8`
    - `SetInt16`
    - `SetInt32`
    - `SetInt64`
    - `SetIntPtr`
    - `SetInt8Ptr`
    - `SetInt16Ptr`
    - `SetInt32Ptr`
    - `SetInt64Ptr`
    - `GetInt`
    - `GetInt8`
    - `GetInt16`
    - `GetInt32`
    - `GetInt64`
    - `GetIntPtr`
    - `GetInt8Ptr`
    - `GetInt16Ptr`
    - `GetInt32Ptr`
    - `GetInt64Ptr`
- Added the following functions to the `attribute/float64` type:
    - `SetFloat32`
    - `SetFloat64`
    - `SetFloat32Ptr`
    - `SetFloat64Ptr`
    - `GetFloat32`
    - `GetFloat64`
    - `GetFloat32Ptr`
    - `GetFloat64Ptr`
- Added the `SetPtr` function to the `attribute/string` and `attribute/bool` types.
- Modified the `Set` function of the `attribute/string` type to set the attribute to null if the value is an empty string.

## Checklist
- [x] Tests added
- [x] Changelog updated